### PR TITLE
013: Use sed instead of ack in the solution

### DIFF
--- a/013_text_highlight/problem/expected.txt
+++ b/013_text_highlight/problem/expected.txt
@@ -1,28 +1,28 @@
 
 CHAPTER II
 
-SATURDAY morning was come, and all [1;31mthe[0m summer world was bright and[0m[K
+SATURDAY morning was come, and all [1;31mthe[0m summer world was bright and
 fresh, and brimming with life. There was a song in every heart; and if
-[1;31mthe[0m heart was young [1;31mthe[0m music issued at [1;31mthe[0m lips. There was cheer in[0m[K
+[1;31mthe[0m heart was young [1;31mthe[0m music issued at [1;31mthe[0m lips. There was cheer in
 every face and a spring in every step. The locust-trees were in bloom
-and [1;31mthe[0m fragrance of [1;31mthe[0m blossoms filled [1;31mthe[0m air. Cardiff Hill, beyond[0m[K
-[1;31mthe[0m village and above it, was green with vegetation and it lay just far[0m[K
+and [1;31mthe[0m fragrance of [1;31mthe[0m blossoms filled [1;31mthe[0m air. Cardiff Hill, beyond
+[1;31mthe[0m village and above it, was green with vegetation and it lay just far
 enough away to seem a Delectable Land, dreamy, reposeful, and inviting.
 
-Tom appeared on [1;31mthe[0m sidewalk with a bucket of whitewash and a[0m[K
-long-handled brush. He surveyed [1;31mthe[0m fence, and all gladness left him and[0m[K
+Tom appeared on [1;31mthe[0m sidewalk with a bucket of whitewash and a
+long-handled brush. He surveyed [1;31mthe[0m fence, and all gladness left him and
 a deep melancholy settled down upon his spirit. Thirty yards of board
 fence nine feet high. Life to him seemed hollow, and existence but a
-burden. Sighing, he dipped his brush and passed it along [1;31mthe[0m topmost[0m[K
-plank; repeated [1;31mthe[0m operation; did it again; compared [1;31mthe[0m insignificant[0m[K
-whitewashed streak with [1;31mthe[0m far-reaching continent of unwhitewashed[0m[K
+burden. Sighing, he dipped his brush and passed it along [1;31mthe[0m topmost
+plank; repeated [1;31mthe[0m operation; did it again; compared [1;31mthe[0m insignificant
+whitewashed streak with [1;31mthe[0m far-reaching continent of unwhitewashed
 fence, and sat down on a tree-box discouraged. Jim came skipping out at
-[1;31mthe[0m gate with a tin pail, and singing Buffalo Gals. Bringing water from[0m[K
-[1;31mthe[0m town pump had always been hateful work in Tom's eyes, before, but[0m[K
+[1;31mthe[0m gate with a tin pail, and singing Buffalo Gals. Bringing water from
+[1;31mthe[0m town pump had always been hateful work in Tom's eyes, before, but
 now it did not strike him so. He remembered that there was company at
-[1;31mthe[0m pump. White, mulatto, and negro boys and girls were always there[0m[K
+[1;31mthe[0m pump. White, mulatto, and negro boys and girls were always there
 waiting their turns, resting, trading playthings, quarrelling,
-fighting, skylarking. And he remembered that although [1;31mthe[0m pump was only[0m[K
+fighting, skylarking. And he remembered that although [1;31mthe[0m pump was only
 a hundred and fifty yards off, Jim never got back with a bucket of
 water under an hour--and even then somebody generally had to go after
 him. Tom said:

--- a/013_text_highlight/solution/compare.sh
+++ b/013_text_highlight/solution/compare.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
 
-# this grep solution almost works
+# these solutions almost work
 #   grep -E '(\bthe\b|$)' --color=always "$@"
+#   ack -w the --passthru --color "$@"
 # it looks fine visually but inserts an invisble
 # escape sequence at the end of the line.
 
 convert() {
-  ack -w the --passthru --color "$@"
+  sed 's/\bthe\b/\x1b[1;31m&\x1b[0m/g' "$@"
 }
 
 convert input.txt > actual.txt

--- a/013_text_highlight/solution/expected.txt
+++ b/013_text_highlight/solution/expected.txt
@@ -1,28 +1,28 @@
 
 CHAPTER II
 
-SATURDAY morning was come, and all [1;31mthe[0m summer world was bright and[0m[K
+SATURDAY morning was come, and all [1;31mthe[0m summer world was bright and
 fresh, and brimming with life. There was a song in every heart; and if
-[1;31mthe[0m heart was young [1;31mthe[0m music issued at [1;31mthe[0m lips. There was cheer in[0m[K
+[1;31mthe[0m heart was young [1;31mthe[0m music issued at [1;31mthe[0m lips. There was cheer in
 every face and a spring in every step. The locust-trees were in bloom
-and [1;31mthe[0m fragrance of [1;31mthe[0m blossoms filled [1;31mthe[0m air. Cardiff Hill, beyond[0m[K
-[1;31mthe[0m village and above it, was green with vegetation and it lay just far[0m[K
+and [1;31mthe[0m fragrance of [1;31mthe[0m blossoms filled [1;31mthe[0m air. Cardiff Hill, beyond
+[1;31mthe[0m village and above it, was green with vegetation and it lay just far
 enough away to seem a Delectable Land, dreamy, reposeful, and inviting.
 
-Tom appeared on [1;31mthe[0m sidewalk with a bucket of whitewash and a[0m[K
-long-handled brush. He surveyed [1;31mthe[0m fence, and all gladness left him and[0m[K
+Tom appeared on [1;31mthe[0m sidewalk with a bucket of whitewash and a
+long-handled brush. He surveyed [1;31mthe[0m fence, and all gladness left him and
 a deep melancholy settled down upon his spirit. Thirty yards of board
 fence nine feet high. Life to him seemed hollow, and existence but a
-burden. Sighing, he dipped his brush and passed it along [1;31mthe[0m topmost[0m[K
-plank; repeated [1;31mthe[0m operation; did it again; compared [1;31mthe[0m insignificant[0m[K
-whitewashed streak with [1;31mthe[0m far-reaching continent of unwhitewashed[0m[K
+burden. Sighing, he dipped his brush and passed it along [1;31mthe[0m topmost
+plank; repeated [1;31mthe[0m operation; did it again; compared [1;31mthe[0m insignificant
+whitewashed streak with [1;31mthe[0m far-reaching continent of unwhitewashed
 fence, and sat down on a tree-box discouraged. Jim came skipping out at
-[1;31mthe[0m gate with a tin pail, and singing Buffalo Gals. Bringing water from[0m[K
-[1;31mthe[0m town pump had always been hateful work in Tom's eyes, before, but[0m[K
+[1;31mthe[0m gate with a tin pail, and singing Buffalo Gals. Bringing water from
+[1;31mthe[0m town pump had always been hateful work in Tom's eyes, before, but
 now it did not strike him so. He remembered that there was company at
-[1;31mthe[0m pump. White, mulatto, and negro boys and girls were always there[0m[K
+[1;31mthe[0m pump. White, mulatto, and negro boys and girls were always there
 waiting their turns, resting, trading playthings, quarrelling,
-fighting, skylarking. And he remembered that although [1;31mthe[0m pump was only[0m[K
+fighting, skylarking. And he remembered that although [1;31mthe[0m pump was only
 a hundred and fifty yards off, Jim never got back with a bucket of
 water under an hour--and even then somebody generally had to go after
 him. Tom said:


### PR DESCRIPTION
ack, like grep, inserts extra escape sequences.

Fixes #2.
